### PR TITLE
Update to support newer rnp versions, and update CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,18 @@ git:
 services:
   - docker
 
+env:
+  - VERSION=0.9.2
+  - VERSION=0.10.0
+  - NEWEST
+
 before_install:
   - docker pull centos:7
 
 script:
   - docker run
       --env CI=true
+      --env VERSION=$VERSION
       --rm
       --volume $PWD/common:/usr/local/rpm-specs
       --volume $PWD:/usr/local/rpm-specs/package

--- a/prepare.sh
+++ b/prepare.sh
@@ -39,7 +39,18 @@ if [[ "${SOURCE}" = git ]]; then
 	cd ~/"rpmbuild/SOURCES/${SOURCE_PATH}"
 else
 	# $VERSION is only for downloading the package archive from a URL.
-	VERSION=${VERSION:-0.9.2}
+        if [ -z "$VERSION" ]; then
+          echo "VERSION NOT SET"
+          release_data=$(curl -s -X GET                       \
+            -H "Content-Type: application/json"               \
+            -H "Accept: application/json"                     \
+            https://api.github.com/repos/riboseinc/rnp/tags   \
+            | jq .[0]
+          )
+          VERSION=$(echo "$release_data" | jq -r .name | cut -c 2-)
+        else
+          echo "VERSION IS SET: ${VERSION}"
+        fi
 
 	curl -LO "https://github.com/riboseinc/rnp/archive/v${VERSION}.tar.gz"
 	tar -xzf "v${VERSION}.tar.gz"


### PR DESCRIPTION
This way, CI would test against 0.9.2, 0.10.0, and whatever the newest is (in this case, same as 0.10.0).